### PR TITLE
Add new _geo_disk_size to get disk size information

### DIFF
--- a/src/hastings_fabric_info.erl
+++ b/src/hastings_fabric_info.erl
@@ -18,15 +18,14 @@
 -include_lib("couch/include/couch_db.hrl").
 
 
--export([go/3]).
+-export([go/4]).
 
 
-go(DbName, DDocId, IndexName) when is_binary(DDocId) ->
+go(DbName, DDocId, IndexName, StartFun) when is_binary(DDocId) ->
     {ok, DDoc} = fabric:open_doc(DbName, <<"_design/", DDocId/binary>>, []),
-    go(DbName, DDoc, IndexName);
+    go(DbName, DDoc, IndexName, StartFun);
 
-go(DbName, DDoc, IndexName) ->
-    StartFun = info,
+go(DbName, DDoc, IndexName, StartFun) ->
     StartArgs = [fabric_util:doc_id_and_rev(DDoc), IndexName],
     case hastings_fabric:run(DbName, StartFun, StartArgs) of
         {ok, Resps} ->

--- a/src/hastings_httpd_handlers.erl
+++ b/src/hastings_httpd_handlers.erl
@@ -21,4 +21,7 @@ db_handler(_) -> no_match.
 
 design_handler(<<"_geo">>)      -> fun hastings_httpd:handle_search_req/3;
 design_handler(<<"_geo_info">>) -> fun hastings_httpd:handle_info_req/3;
+design_handler(<<"_geo_disk_size">>) ->
+    fun hastings_httpd:handle_disk_size_req/3;
+
 design_handler(_) -> no_match.

--- a/src/hastings_index.erl
+++ b/src/hastings_index.erl
@@ -31,6 +31,7 @@
     await/2,
     search/2,
     info/1,
+    disk_size/2,
 
     set_update_seq/2,
     update/3,
@@ -142,6 +143,11 @@ update(Pid, Id, Geoms) ->
 
 remove(Pid, Id) ->
     gen_server:call(Pid, {remove, Id}, infinity).
+
+
+disk_size(DbName, Sig) ->
+    IdxDir = index_directory(DbName, Sig),
+    easton_index:disk_size(IdxDir).
 
 
 init({Manager, DbName, Index, Generation}) ->

--- a/src/hastings_rpc.erl
+++ b/src/hastings_rpc.erl
@@ -20,7 +20,8 @@
 
 -export([
     search/4,
-    info/3
+    info/3,
+    disk_size/3
 ]).
 
 
@@ -48,6 +49,17 @@ info(Shard, DDocInfo, IndexName) ->
     DDoc = get_ddoc(Shard, DDocInfo),
     Pid = get_index_pid(Shard#shard.name, DDoc, IndexName),
     reply(hastings_index:info(Pid)).
+
+
+disk_size(Shard, DDocInfo, IndexName) ->
+    erlang:put(io_priority, {interactive, Shard#shard.name}),
+    DDoc = get_ddoc(Shard, DDocInfo),
+    Index = case hastings_index:design_doc_to_index(DDoc, IndexName) of
+        {ok, Index0} -> Index0;
+        Error1 -> reply(Error1)
+    end,
+    DiskSize = hastings_index:disk_size(Shard#shard.name, Index#h_idx.sig),
+    reply(DiskSize).
 
 
 get_ddoc(Shard, {DDocId, Rev}) ->

--- a/test/hastings_disk_size_tests.erl
+++ b/test/hastings_disk_size_tests.erl
@@ -1,0 +1,82 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(hastings_disk_size_tests).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+
+
+-define(TIMEOUT, 10000).
+
+
+setup() ->
+    DbName = ?tempdb(),
+    ok = fabric:create_db(DbName, [?ADMIN_CTX]),
+    DbName.
+
+
+teardown(DbName) ->
+    ok = fabric:delete_db(DbName, [?ADMIN_CTX]).
+
+
+disk_size_test_() ->
+    {
+        "hastings handle disk size test",
+        {
+            setup,
+            fun() -> test_util:start_couch([fabric, mem3, hastings, easton]) end,
+            fun test_util:stop/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun disk_size_test/1
+                ]
+            }
+        }
+    }.
+
+
+disk_size_test(DbName) ->
+    ?_test(begin
+        Fn = filename:join([?APPDIR, "test", "testdata", "geo_docs2.json"]),
+        {ok, Bin} = file:read_file(Fn),
+        DocsArray = jiffy:decode(Bin),
+        Docs = [couch_doc:from_json_obj(JsonObj) || JsonObj <- DocsArray],
+
+        DesignFn = filename:join([?APPDIR, "test", "testdata",
+            "geo_design.json"]),
+        {ok, Bin2} = file:read_file(DesignFn),
+        JsonDDoc = jiffy:decode(Bin2),
+        DDoc = couch_doc:from_json_obj(JsonDDoc),
+
+        AllDocs = [DDoc|Docs],
+        {ok, _} = fabric:update_docs(DbName, AllDocs, [?ADMIN_CTX]),
+
+        % check that disk_size query doesn't open any hastings_index processes
+        IndexName = <<"geoidx">>,
+        {ok, DDoc1} = fabric:open_doc(DbName, <<"_design/geodd">>, [?ADMIN_CTX]),
+        hastings_fabric_info:go(DbName, DDoc1, IndexName, disk_size),
+        Size = ets:info(hastings_by_pid, size),
+        ?assertEqual(0, Size),
+
+        % check that disk_size query response is in the proper format
+        HQArgs = {h_args,{ circle, {-71.12087954, 42.35182135 ,100.0}}, false,
+            <<"contains">>, default, default, undefined, undefined, undefined,
+            25, 0, false, false, false, true, [], hastings_format_view, []},
+        hastings_fabric_search:go(DbName, DDoc1, IndexName, HQArgs),
+        Resp = hastings_fabric_info:go(DbName, DDoc1, IndexName, disk_size),
+        ?assertMatch({ok,[{disk_size, X}]} when X>0, Resp),
+        ok
+    end).

--- a/test/testdata/geo_docs2.json
+++ b/test/testdata/geo_docs2.json
@@ -1,0 +1,46 @@
+[
+  {
+    "_id": "79f14b64c57461584b152123e392f263",
+    "geometry": {
+      "coordinates": [
+        -71.12087954,
+        42.35182135
+      ],
+      "type": "Point"
+    },
+    "type": "Feature"
+  },
+  {
+    "_id": "79f14b64c57461584b152123e392ed9d",
+    "geometry": {
+      "coordinates": [
+        -71.15209161,
+        42.35993593
+      ],
+      "type": "Point"
+    },
+    "type": "Feature"
+  },
+  {
+    "_id": "79f14b64c57461584b152123e392e828",
+    "geometry": {
+      "coordinates": [
+        -71.05998657,
+        42.36164815
+      ],
+      "type": "Point"
+    },
+    "type": "Feature"
+  },
+  {
+    "_id": "79f14b64c57461584b152123e392da64",
+    "geometry": {
+      "coordinates": [
+        -71.09674435,
+        42.34874916
+      ],
+      "type": "Point"
+    },
+    "type": "Feature"
+  }
+]


### PR DESCRIPTION
Currently the only way to get the disk size information for hastings
index is to use the _geo_info endpoint. But using this endpoint would
open databases along with hastings_index and easton processes.

This change adds a new end point _geo_disk_size to get the
disk size information without opening databases and indexes.
It works by scanning geo directory and summing up the file
sizes there.

Usage:
<dbname>/_design/<DDoc>/_geo_disk_size/<IndexName>

Example reply:
{
  "name": "_design/geodd/geoidx",
  "geo_index": {
    "disk_size": 9646
  }
}

There is also a companion easton PR.

BugzID: 89995