### PR TITLE
Remove couch_crypto

### DIFF
--- a/src/hastings_index.erl
+++ b/src/hastings_index.erl
@@ -428,7 +428,7 @@ set_index_sig(Idx) ->
         Idx#h_idx.dimensions,
         Idx#h_idx.srid
     },
-    Sig = ?l2b(couch_util:to_hex(couch_crypto:hash(md5,term_to_binary(SigTerm)))),
+    Sig = ?l2b(couch_util:to_hex(crypto:hash(md5,term_to_binary(SigTerm)))),
     Idx#h_idx{sig = Sig}.
 
 


### PR DESCRIPTION
The crypto:hash function exists
in all the versions of erlang supported by CouchDB.