### PR TITLE
Rename geo index directories in place when database is deleted

### DIFF
--- a/test/hastings_delete_db_test.erl
+++ b/test/hastings_delete_db_test.erl
@@ -1,0 +1,139 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(hastings_delete_db_test).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/include/mem3.hrl").
+-include_lib("hastings/src/hastings.hrl").
+
+
+-define(TIMEOUT, 10000).
+
+
+setup() ->
+    DbName = ?tempdb(),
+    ok = fabric:create_db(DbName, [?ADMIN_CTX]),
+    meck:new(hastings_vacuum, [passthrough]),
+    meck:expect(hastings_vacuum, clean_db, fun(A) ->
+        meck:passthrough([A])
+    end),
+    DbName.
+
+
+teardown(_DbName) ->
+    (catch meck:unload(hastings_vacuum)).
+
+
+hastings_delete_db_test_() ->
+    {
+        "Hastings Delete Database Tests",
+        {
+            setup,
+            fun() -> test_util:start_couch([fabric, mem3, hastings]) end,
+            fun test_util:stop/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun should_delete_index_after_deleting_database/1,
+                    fun should_rename_index_after_deleting_database/1
+                ]
+            }
+        }
+    }.
+
+
+should_delete_index_after_deleting_database(DbName) ->
+    ?_test(begin
+        Docs = hastings_test_util:make_docs(5),
+        {ok, _} = fabric:update_docs(DbName, Docs, [?ADMIN_CTX]),
+        {ok, _} = fabric:update_doc(
+          DbName,
+          hastings_test_util:ddoc(geo),
+          [?ADMIN_CTX]
+        ),
+        
+        {ok, Hits} = run_hastings_search(DbName),
+        ?assertEqual(5, lists:flatlength(Hits)),
+        
+        config:set("couchdb", "enable_database_recovery", "false", false),
+        BaseDir = config:get("couchdb", "geo_index_dir", "/srv/geo_index"),
+
+        [FirstShard | _RestShards] = mem3:shards(DbName),
+        [GeoIdxDir | _RestIdxDirs] = hastings_util:get_existing_index_dirs(
+            BaseDir,
+            FirstShard#shard.name
+        ),
+        GeoDirExistsBefore = filelib:is_dir(GeoIdxDir),
+        
+        fabric:delete_db(DbName, [?ADMIN_CTX]),
+        meck:wait(hastings_vacuum, clean_shard_db, '_', 5000),
+        
+        RenamedPath = hastings_util:calculate_delete_directory(GeoIdxDir),
+        GeoDirExistsAfter = filelib:is_dir(GeoIdxDir),
+        GeoRenamedDirExistsAfter = filelib:is_dir(RenamedPath),
+        
+        [
+            ?assert(GeoDirExistsBefore),
+            ?assertNot(GeoDirExistsAfter),
+            ?assertNot(GeoRenamedDirExistsAfter)
+        ]
+    end).
+
+
+should_rename_index_after_deleting_database(DbName) ->
+    ?_test(begin
+        Docs = hastings_test_util:make_docs(5),
+        {ok, _} = fabric:update_docs(DbName, Docs, [?ADMIN_CTX]),
+        {ok, _} = fabric:update_doc(
+            DbName,
+            hastings_test_util:ddoc(geo),
+            [?ADMIN_CTX]
+        ),
+    
+        {ok, Hits} = run_hastings_search(DbName),
+        ?assertEqual(5, lists:flatlength(Hits)),
+    
+        config:set("couchdb", "enable_database_recovery", "true", false),
+        BaseDir = config:get("couchdb", "geo_index_dir", "/srv/geo_index"),
+
+        [FirstShard | _RestShards] = mem3:shards(DbName),
+        [GeoIdxDir | _RestIdxDirs] = hastings_util:get_existing_index_dirs(
+            BaseDir,
+            FirstShard#shard.name
+        ),
+        GeoDirExistsBefore = filelib:is_dir(GeoIdxDir),
+    
+        fabric:delete_db(DbName, [?ADMIN_CTX]),
+        meck:wait(hastings_vacuum, clean_shard_db, '_', 5000),
+
+        RenamedPath = hastings_util:calculate_delete_directory(
+            filename:dirname(GeoIdxDir)
+        ),
+        GeoDirExistsAfter = filelib:is_dir(GeoIdxDir),
+        GeoRenamedDirExistsAfter = filelib:is_dir(RenamedPath),
+    
+        [
+            ?assert(GeoDirExistsBefore),
+            ?assertNot(GeoDirExistsAfter),
+            ?assert(GeoRenamedDirExistsAfter)
+        ]
+    end).
+
+
+run_hastings_search(DbName) ->
+    HQArgs = #h_args{geom = {bbox,[-180.0,-90.0,180.0,90.0]}},
+    {ok, DDoc} = fabric:open_doc(DbName, <<"_design/geodd">>, []),
+    hastings_fabric_search:go(DbName, DDoc, <<"geoidx">>, HQArgs).

--- a/test/hastings_test_util.erl
+++ b/test/hastings_test_util.erl
@@ -1,0 +1,53 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(hastings_test_util).
+
+-compile(export_all).
+
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("couch/include/couch_eunit.hrl").
+
+
+save_docs(DbName, Docs) ->
+    {ok, _} = fabric:update_docs(DbName, Docs, [?ADMIN_CTX]).
+
+
+make_docs(Count) ->
+    [doc(I) || I <- lists:seq(1, Count)].
+
+
+ddoc(geo) ->
+    couch_doc:from_json_obj({[
+        {<<"_id">>, <<"_design/geodd">>},
+        {<<"st_indexes">>, {[
+            {<<"geoidx">>, {[
+                {<<"index">>, <<
+                    "function(doc) {"
+                    "  if (doc.geometry && doc.geometry.coordinates)"
+                    "    {st_index(doc.geometry);}"
+                    "}"
+                >>}
+            ]}}
+        ]}}
+    ]}).
+
+
+doc(Id) ->
+    couch_doc:from_json_obj({[
+        {<<"_id">>, list_to_binary("point" ++ integer_to_list(Id))},
+        {<<"val">>, Id},
+        {<<"geometry">>, {[
+            {<<"type">>, <<"Point">>},
+            {<<"coordinates">>, [Id, Id]}
+        ]}}
+    ]}).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview
Before change, the geo index directories and files were not deleted when database was deleted. This will cause orphan geo index files and directories. In detail, when database was deleted, the `gen_server:cast(?MODULE, {cleanup, DbName})` was called in 
https://github.com/cloudant-labs/hastings/blob/master/src/hastings_vacuum.erl#L99.  Later,  ` {ok, JsonDDocs} = get_ddocs(DbName)` in `clean_db/1` was called. Because database was deleted,  `{'DOWN', Ref, _, _, {error, database_does_not_exist}} ` message was sent in https://github.com/cloudant-labs/hastings/blob/master/src/hastings_vacuum.erl#L149. Finally, `cleanup(DbName, ActiveSigs)` was not called in https://github.com/cloudant-labs/hastings/blob/master/src/hastings_vacuum.erl#L127. 

This PR is aimed to address above issue and take action against geo index when database is deleted.

The direct approach is to delete geo index files and directoires when database is deleted, i.e. https://github.com/cloudant-labs/hastings/pull/3/files#diff-7ac6be6388d90e131766d8c5824cb226R259

 The second approach is to rename geo index in place such as from `/srv/geo_index/shards/60000000-7fffffff/<dbname.ts>/e66df316792ab411705e2741bba44371`  to  `/srv/geo_index/shards/60000000-7fffffff/<dbname.YYMMDD.HHMMSS.deleted.ts>/e66df316792ab411705e2741bba44371` when the corresponding database was deleted and "enable_database_recovery" configuration item is set to true. This allows geo index files to be re-used if database is recovered. 
https://github.com/cloudant-labs/hastings/pull/3/files#diff-7ac6be6388d90e131766d8c5824cb226R259

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

## Testing recommendations
```
make check apps=hastings skip_deps+=couch_epi tests=hastings_delete_db_test_
    Running test function(s):
     ======================== EUnit ========================
Hastings Delete Database Tests
  hastings_delete_db_test:58: should_delete_index_after_deleting_database...[0.402 s] ok
  hastings_delete_db_test:93: should_rename_index_after_deleting_database...[0.158 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 1.075 s]
=======================================================
  2 tests passed.
```
<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->

## GitHub issue number
Bugzid: 86318

<!-- If this is a significant change, please file a separate issue at:
     https://github.com/apache/couchdb/issues
     and include the number here and in commit message(s) using
     syntax like "Fixes #472" or "Fixes apache/couchdb#472".  -->

## Related Pull Requests
https://github.com/cloudant-labs/hastings/pull/3 was deprecated with this PR
https://github.com/cloudant/chef-repo/pull/7719
<!-- If your changes affects multiple components in different
     repositories please put links to those pull requests here.  -->
N/A
## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;
