### PR TITLE
Allow for mixed cluster upgrades

### DIFF
--- a/src/hastings_index.erl
+++ b/src/hastings_index.erl
@@ -159,7 +159,7 @@ init({Manager, DbName, Index, Generation}) ->
             St = #st{
                 manager = Manager,
                 index = NewIndex,
-                dbpid = Db#db.main_pid,
+                dbpid = couch_db:get_pid(Db),
                 generation = Generation
             },
             gen_server:enter_loop(?MODULE, [], St);


### PR DESCRIPTION
This removes the sharing of the #shard record across nodes so that mixed
clusters can still service geo index requests during an upgrade that
changes the #shard record.

COUCHDB-3288