### PR TITLE
Use 8 instead of 4 to check the completion of index soft-deletion for all shards

### DIFF
--- a/test/hastings_delete_db_test.erl
+++ b/test/hastings_delete_db_test.erl
@@ -122,7 +122,7 @@ should_rename_index_after_deleting_database(DbName) ->
         GeoDirExistsBefore = filelib:is_dir(GeoIdxDir),
     
         fabric:delete_db(DbName, [?ADMIN_CTX]),
-        meck:wait(4, hastings_util, do_rename, '_', 5000),
+        meck:wait(8, hastings_util, do_rename, '_', 5000),
 
         RenamedPath = hastings_util:calculate_delete_directory(
             filename:dirname(GeoIdxDir)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
The eunit test case  `should_rename_index_after_deleting_database/1` randomly failed in remote build. It turns out that it needs to wait for the completion of index soft-deletion for all shards. The number should be 8 instead of 4.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=hastings
## Related Issues or Pull Requests
Bugzid: 86318
<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [ ] Documentation reflects the changes;