### PR TITLE
Couchdb 3326 clustered purge

### DIFF
--- a/src/hastings_plugin_couch_db.erl
+++ b/src/hastings_plugin_couch_db.erl
@@ -10,41 +10,20 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
--module(hastings_epi).
+-module(hastings_plugin_couch_db).
 
--behaviour(couch_epi_plugin).
+-include_lib("couch/include/couch_eunit.hrl").
+
 
 -export([
-    app/0,
-    providers/0,
-    services/0,
-    data_subscriptions/0,
-    data_providers/0,
-    processes/0,
-    notify/3
+    is_valid_purge_client/2,
+    on_compact/2
 ]).
 
-app() ->
-    hastings.
 
-providers() ->
-    [
-        {couch_db, hastings_plugin_couch_db},
-        {chttpd_handlers, hastings_httpd_handlers}
-    ].
+is_valid_purge_client(DbName, Props) ->
+    hastings_util:verify_index_exists(DbName, Props).
 
 
-services() ->
-    [].
-
-data_subscriptions() ->
-    [].
-
-data_providers() ->
-    [].
-
-processes() ->
-    [].
-
-notify(_Key, _Old, _New) ->
-    ok.
+on_compact(DbName, DDocs) ->
+    hastings_util:ensure_local_purge_docs(DbName, DDocs).

--- a/src/hastings_rpc.erl
+++ b/src/hastings_rpc.erl
@@ -22,7 +22,8 @@
     search/4,
     search/5,
     info/3,
-    info/4
+    info/4,
+    reply/1
 ]).
 
 
@@ -38,15 +39,15 @@ search(ShardName, ShardRange, DDocInfo, IndexName, HQArgs0) ->
     Pid = get_index_pid(ShardName, DDoc, IndexName),
     case hastings_index:await(Pid, AwaitSeq) of
         {ok, _} -> ok;
-        Error -> reply(Error)
+        Error -> hastings_rpc:reply(Error)
     end,
     case hastings_index:search(Pid, HQArgs) of
         {ok, Results0} ->
             MapFun = fun(Result) -> fmt_result(node(), ShardRange, Result) end,
             Results = lists:map(MapFun, Results0),
-            reply({ok, Results});
+            hastings_rpc:reply({ok, Results});
         Else ->
-            reply(Else)
+            hastings_rpc:reply(Else)
     end.
 
 
@@ -58,7 +59,7 @@ info(ShardName, _ShardRange, DDocInfo, IndexName) ->
     erlang:put(io_priority, {interactive, ShardName}),
     DDoc = get_ddoc(ShardName, DDocInfo),
     Pid = get_index_pid(ShardName, DDoc, IndexName),
-    reply(hastings_index:info(Pid)).
+    hastings_rpc:reply(hastings_index:info(Pid)).
 
 
 get_ddoc(ShardName, {DDocId, Rev}) ->
@@ -82,11 +83,11 @@ set_bookmark(ShardRange, #h_args{bookmark=Bookmark} = HQArgs) ->
 get_index_pid(DbName, DDoc, IndexName) ->
     Index = case hastings_index:design_doc_to_index(DDoc, IndexName) of
         {ok, Index0} -> Index0;
-        Error1 -> reply(Error1)
+        Error1 -> hastings_rpc:reply(Error1)
     end,
     case hastings_index_manager:get_index(DbName, Index) of
         {ok, Pid} -> Pid;
-        Error2 -> reply(Error2)
+        Error2 -> hastings_rpc:reply(Error2)
     end.
 
 

--- a/test/hastings_purge_docs_test.erl
+++ b/test/hastings_purge_docs_test.erl
@@ -1,0 +1,390 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(hastings_purge_docs_test).
+
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch/include/couch_db.hrl").
+-include_lib("mem3/include/mem3.hrl").
+-include_lib("hastings/src/hastings.hrl").
+
+
+-define(TIMEOUT, 10000).
+
+
+setup() ->
+    {ok, Db} = hastings_test_util:init_db(?tempdb(), 5),
+    meck:new(hastings_util, [passthrough]),
+    meck:expect(hastings_util, ensure_local_purge_docs, fun(A, B) ->
+        meck:passthrough([A, B])
+    end),
+    meck:new(hastings_rpc, [non_strict, passthrough]),
+    meck:expect(hastings_rpc, reply, fun (Msg) -> Msg end),
+    Db.
+
+
+teardown(Db) ->
+    couch_db:close(Db),
+    couch_server:delete(couch_db:name(Db), [?ADMIN_CTX]),
+    meck:unload(hastings_util),
+    meck:unload(hastings_rpc),
+    ok.
+
+
+hastings_purge_test_() ->
+    {
+        "Hastings Purge Tests",
+        {
+            setup,
+            fun() -> test_util:start_couch([fabric, mem3, hastings]) end,
+            fun test_util:stop/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun test_purge_single/1,
+                    fun test_purge_multiple/1,
+                    fun test_purge_multiple2/1,
+                    fun test_purge_local_purge_doc/1,
+                    fun test_purge_verify_index/1,
+                    fun test_purge_remove_local_purge_doc/1,
+                    fun test_purge_hook_before_compaction/1
+                ]
+            }
+        }
+    }.
+
+
+test_purge_single(Db) ->
+    ?_test(begin
+        {ok, Hits} = run_hastings_search(Db),
+        ?assertEqual(5, lists:flatlength(Hits)),
+        DocIds = [
+            <<"point1">>
+        ],
+        purge_docs(Db, DocIds),
+        {ok, Db2} = couch_db:reopen(Db),
+        {ok, Hits1} = run_hastings_search(Db2),
+        ?assertEqual(4, lists:flatlength(Hits1)),
+
+        ok
+    end).
+
+test_purge_multiple(Db) ->
+    ?_test(begin
+        {ok, Hits} = run_hastings_search(Db),
+        ?assertEqual(5, lists:flatlength(Hits)),
+
+        DocIds = [
+            <<"point1">>,
+            <<"point2">>,
+            <<"point3">>,
+            <<"point4">>
+        ],
+        purge_docs(Db, DocIds),
+        {ok, Db2} = couch_db:reopen(Db),
+        {ok, Hits1} = run_hastings_search(Db2),
+        ?assertEqual(1, lists:flatlength(Hits1)),
+
+        ok
+    end).
+
+test_purge_multiple2(Db) ->
+    ?_test(begin
+        {ok, Hits} = run_hastings_search(Db),
+        ?assertEqual(5, lists:flatlength(Hits)),
+
+        DocIds1 = [
+            <<"point1">>,
+            <<"point2">>
+        ],
+        purge_docs(Db, DocIds1),
+        {ok, Db2} = couch_db:reopen(Db),
+        {ok, Hits1} = run_hastings_search(Db2),
+        ?assertEqual(3, lists:flatlength(Hits1)),
+
+        DocIds2 = [
+            <<"point3">>,
+            <<"point4">>
+        ],
+        purge_docs(Db, DocIds2),
+        {ok, Db3} = couch_db:reopen(Db2),
+        {ok, Hits2} = run_hastings_search(Db3),
+        ?assertEqual(1, lists:flatlength(Hits2)),
+
+        ok
+    end).
+
+test_purge_local_purge_doc(Db) ->
+    ?_test(begin
+        {ok, Hits} = run_hastings_search(Db),
+        ?assertEqual(5, lists:flatlength(Hits)),
+
+        DocIds1 = [
+            <<"point1">>
+        ],
+        purge_docs(Db, DocIds1),
+
+        {ok, Hits1} = run_hastings_search(Db),
+        ?assertEqual(4, lists:flatlength(Hits1)),
+
+        {ok, DDoc} = couch_db:open_doc(Db, <<"_design/geodd">>, []),
+        {ok, Idx} = hastings_index:design_doc_to_index(DDoc, <<"geoidx">>),
+        {ok, Db2} = couch_db:reopen(Db),
+
+        {ok, LocalPurgeDoc1} = couch_db:open_doc(
+            Db2,
+            hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+            []
+        ),
+        {Props1} = couch_doc:to_json_obj(LocalPurgeDoc1, []),
+        Rev1 = couch_util:get_value(<<"_rev">>, Props1),
+        ?assertEqual(<<"0-1">>, Rev1),
+
+        DocIds2 = [
+            <<"point2">>
+        ],
+        purge_docs(Db2, DocIds2),
+
+        {ok, Hits2} = run_hastings_search(Db2),
+        ?assertEqual(3, lists:flatlength(Hits2)),
+
+        {ok, Db3} = couch_db:reopen(Db2),
+        {ok, LocalPurgeDoc2} = couch_db:open_doc(
+            Db3,
+            hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+            []
+        ),
+        {Props2} = couch_doc:to_json_obj(LocalPurgeDoc2, []),
+        Rev2 = couch_util:get_value(<<"_rev">>, Props2),
+        ?assertEqual(<<"0-1">>, Rev2),
+
+        DocIds3 = [
+            <<"point3">>
+        ],
+        purge_docs(Db3, DocIds3),
+
+        {ok, Hits3} = run_hastings_search(Db3),
+        ?assertEqual(2, lists:flatlength(Hits3)),
+
+        {ok, Db4} = couch_db:reopen(Db3),
+        {ok, LocalPurgeDoc3} = couch_db:open_doc(
+            Db4,
+            hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+            []
+        ),
+        {Prop3} = couch_doc:to_json_obj(LocalPurgeDoc3, []),
+        Rev3 = couch_util:get_value(<<"_rev">>, Prop3),
+        ?assertEqual(<<"0-1">>, Rev3),
+
+        ok
+    end).
+
+test_purge_verify_index(Db) ->
+    ?_test(begin
+        {ok, Hits} = run_hastings_search(Db),
+        ?assertEqual(5, lists:flatlength(Hits)),
+
+        DocIds1 = [
+            <<"point1">>,
+            <<"point2">>
+        ],
+        purge_docs(Db, DocIds1),
+
+        {ok, Hits1} = run_hastings_search(Db),
+        ?assertEqual(3, lists:flatlength(Hits1)),
+
+        {ok, DDoc} = couch_db:open_doc(Db, <<"_design/geodd">>, []),
+        {ok, Idx} = hastings_index:design_doc_to_index(DDoc, <<"geoidx">>),
+        {ok, Db2} = couch_db:reopen(Db),
+        {ok, LocPurgeDoc} = couch_db:open_doc(
+            Db2,
+            hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+            []
+        ),
+        #doc{body = {Props}} = LocPurgeDoc,
+        ShardName = couch_db:name(Db),
+        ?assertEqual(true, hastings_util:verify_index_exists(
+            ShardName, Props)),
+
+        ok
+    end).
+
+test_purge_remove_local_purge_doc(Db) ->
+    ?_test(begin
+        {ok, Hits} = run_hastings_search(Db),
+        ?assertEqual(5, lists:flatlength(Hits)),
+        
+        DocIds1 = [
+            <<"point1">>,
+            <<"point2">>
+        ],
+        purge_docs(Db, DocIds1),
+        
+        {ok, Hits1} = run_hastings_search(Db),
+        ?assertEqual(3, lists:flatlength(Hits1)),
+        
+        {ok, DDoc} = couch_db:open_doc(Db, <<"_design/geodd">>, []),
+        {ok, Idx} = hastings_index:design_doc_to_index(DDoc, <<"geoidx">>),
+        {ok, Db2} = couch_db:reopen(Db),
+        {ok, LocalPurgeDoc} = couch_db:open_doc(
+            Db2,
+            hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+            []
+        ),
+        
+        {ok, _} = couch_db:update_doc(
+            Db2,
+            LocalPurgeDoc#doc{deleted=true},
+            [?ADMIN_CTX]
+        ),
+        {ok, Db3} = couch_db:reopen(Db2),
+        Result = couch_db:open_doc(
+            Db3,
+            hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+            []
+        ),
+        ?assertEqual({not_found,missing}, Result),
+        
+        ok
+    end).
+
+
+test_purge_hook_before_compaction(Db) ->
+    ?_test(begin
+        {ok, Hits} = run_hastings_search(Db),
+        ?assertEqual(5, lists:flatlength(Hits)),
+
+        purge_docs(Db, [<<"point1">>]),
+        {ok, Hits1} = run_hastings_search(Db),
+        ?assertEqual(4, lists:flatlength(Hits1)),
+
+        {ok, #doc{body = {Props1}}} = get_local_purge_doc(Db),
+        ?assertEqual(1, couch_util:get_value(<<"purge_seq">>, Props1)),
+
+        {ok, _} = couch_db:start_compact(Db),
+        ShardName = couch_db:name(Db),
+        wait_compaction(ShardName, ?LINE),
+
+        ?assertEqual(ok, meck:wait(1, hastings_util,
+            ensure_local_purge_docs, '_', 5000)
+        ),
+
+        % Make sure compaction didn't change the update seq
+        {ok, #doc{body = {Props1}}} = get_local_purge_doc(Db),
+        ?assertEqual(1, couch_util:get_value(<<"purge_seq">>, Props1)),
+
+        purge_docs(Db, [<<"point2">>]),
+
+        {ok, _} = couch_db:start_compact(Db),
+        wait_compaction(ShardName, ?LINE),
+
+        ?assertEqual(ok, meck:wait(2, hastings_util,
+            ensure_local_purge_docs, '_', 5000)
+        ),
+
+        % Make sure compaction after a purge didn't overwrite
+        % the local purge doc for the index
+        {ok, #doc{body = {Props2}}} = get_local_purge_doc(Db),
+        ?assertEqual(1, couch_util:get_value(<<"purge_seq">>, Props2)),
+
+        % Force another update to ensure that we update
+        % the local doc appropriate after compaction
+        {ok, Hits2} = run_hastings_search(Db),
+        ?assertEqual(3, lists:flatlength(Hits2)),
+
+        {ok, #doc{body = {Props3}}} = get_local_purge_doc(Db),
+        ?assertEqual(2, couch_util:get_value(<<"purge_seq">>, Props3)),
+
+        % Check that if the local doc doesn't exist that one
+        % is created for the index on compaction
+        delete_local_purge_doc(Db),
+        ?assertMatch({not_found, _}, get_local_purge_doc(Db)),
+
+        {ok, _} = couch_db:start_compact(Db),
+        wait_compaction(ShardName, ?LINE),
+
+        ?assertEqual(ok, meck:wait(3, hastings_util,
+            ensure_local_purge_docs, '_', 5000)
+        ),
+
+        {ok, #doc{body = {Props4}}} = get_local_purge_doc(Db),
+        ?assertEqual(2, couch_util:get_value(<<"purge_seq">>, Props4))
+    end).
+
+
+get_local_purge_doc(Db) ->
+    {ok, DDoc} = couch_db:open_doc(Db, <<"_design/geodd">>, []),
+    {ok, Idx} = hastings_index:design_doc_to_index(DDoc, <<"geoidx">>),
+    DocId = hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+    {ok, Db2} = couch_db:reopen(Db),
+    couch_db:open_doc(Db2, DocId, []).
+
+
+delete_local_purge_doc(Db) ->
+    {ok, DDoc} = couch_db:open_doc(Db, <<"_design/geodd">>, []),
+    {ok, Idx} = hastings_index:design_doc_to_index(DDoc, <<"geoidx">>),
+    DocId = hastings_util:get_local_purge_doc_id(Idx#h_idx.sig),
+    NewDoc = #doc{id = DocId, deleted = true},
+    {ok, Db2} = couch_db:reopen(Db),
+    {ok, _} = couch_db:update_doc(Db2, NewDoc, []).
+
+wait_compaction(DbName, Line) ->
+    WaitFun = fun() ->
+        case is_compaction_running(DbName) of
+            true -> wait;
+            false -> ok
+        end
+    end,
+    case test_util:wait(WaitFun, 10000) of
+        timeout ->
+            erlang:error({assertion_failed, [
+                {module, ?MODULE},
+                {line, Line},
+                {reason, "Timeout waiting for database compaction"}
+            ]});
+        _ ->
+            ok
+    end.
+
+
+is_compaction_running(DbName) ->
+    {ok, DbInfo} = couch_util:with_db(DbName, fun(Db) ->
+        couch_db:get_db_info(Db)
+    end),
+    couch_util:get_value(compact_running, DbInfo).
+
+
+run_hastings_search(Db) ->
+    ShardName = couch_db:name(Db),
+    ShardRange = [0,4294967295],
+    {ok, DDocInfo} = couch_db:open_doc(Db, <<"_design/geodd">>, []),
+    HQArgs0 = #h_args{geom = {bbox,[-180.0,-90.0,180.0,90.0]}},
+    hastings_rpc:search(ShardName, ShardRange, DDocInfo, <<"geoidx">>, HQArgs0).
+
+
+get_rev(#full_doc_info{} = FDI) ->
+    #doc_info{
+        revs = [#rev_info{} = PrevRev | _]
+    } = couch_doc:to_doc_info(FDI),
+    PrevRev#rev_info.rev.
+
+
+purge_docs(Db, DocIds) ->
+    lists:foreach(fun(DocId) ->
+        FDI = couch_db:get_full_doc_info(Db, DocId),
+        Rev = get_rev(FDI),
+        Uuid = couch_uuids:random(),
+        PurgeInfos = [{Uuid, DocId, [Rev]}],
+        {ok, _} = couch_db:purge_docs(Db, PurgeInfos)
+    end, DocIds).

--- a/test/hastings_test_util.erl
+++ b/test/hastings_test_util.erl
@@ -17,9 +17,24 @@
 -include_lib("couch/include/couch_db.hrl").
 -include_lib("couch/include/couch_eunit.hrl").
 
+init_db(Name, Count) ->
+  {ok, Db} = new_db(Name),
+  Docs = make_docs(Count),
+  save_docs(Db, Docs).
 
-save_docs(DbName, Docs) ->
-    {ok, _} = fabric:update_docs(DbName, Docs, [?ADMIN_CTX]).
+
+new_db(Name) ->
+  couch_server:delete(Name, [?ADMIN_CTX]),
+  {ok, Db} = couch_db:create(Name, [?ADMIN_CTX]),
+  save_docs(Db, [ddoc(geo)]).
+
+delete_db(Name) ->
+  couch_server:delete(Name, [?ADMIN_CTX]).
+
+
+save_docs(Db, Docs) ->
+  {ok, _} = couch_db:update_docs(Db, Docs, []),
+  couch_db:reopen(Db).
 
 
 make_docs(Count) ->


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

The primary purpose of clustered purge is to clean databases that have multiple deleted tombstones or single documents that contain large numbers of conflicts. But it can also be used to purge any document (deleted or non-deleted) with any number of revisions.

With PR https://github.com/apache/couchdb/pull/1370, the purge API and update on secondary index are implemented. The current PR is in charge of updating geospatial index according to purge tree and record purge history in local purge document to make sure that the index update is not out of date.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=hastings

```
======================== EUnit ========================
module 'hastings_bookmark'
module 'hastings_format_legacy_local'
module 'hastings_index_updater'
module 'hastings_purge_docs_test'
  Hastings Purge Tests
Application crypto was left running!
    hastings_purge_docs_test:70: test_purge_single...[0.422 s] ok
    hastings_purge_docs_test:90: test_purge_multiple...[0.257 s] ok
    hastings_purge_docs_test:117: test_purge_multiple2...[0.284 s] ok
    hastings_purge_docs_test:151: test_purge_local_purge_doc...[0.384 s] ok
    hastings_purge_docs_test:224: test_purge_verify_index...[0.215 s] ok
    hastings_purge_docs_test:260: test_purge_remove_local_purge_doc...[0.228 s] ok
    hastings_purge_docs_test:307: test_purge_hook_before_compaction...[0.896 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 4.297 s]
  [done in 6.972 s]
module 'hastings_format_view'
module 'hastings_index'
module 'hastings_util'
module 'hastings_fabric'
module 'hastings_httpd_handlers'
module 'hastings_rpc'
hastings_index_test: design_doc_to_index_int_test (module 'hastings_index_test')...[0.072 s] ok
module 'hastings_delete_db_test'
  Hastings Delete Database Tests
    hastings_delete_db_test:65: should_delete_index_after_deleting_database...[0.294 s] ok
    hastings_delete_db_test:104: should_rename_index_after_deleting_database...[0.284 s] ok
erl_child_setup: failed with error 32 on line 240
erl_child_setup: failed with error 32 on line 240
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
erl_child_setup: failed with error 32 on line 240
erl_child_setup: failed with error 32 on line 240
    [done in 1.247 s]
  [done in 1.381 s]
module 'hastings_plugin_couch_db'
module 'hastings_index_manager'
module 'hastings_fabric_info'
module 'hastings_vacuum'
module 'hastings_format_geojson'
module 'hastings_test_util'
module 'hastings_epi'
module 'hastings_httpd'
module 'hastings_app'
module 'hastings_format'
module 'hastings_httpd_util'
module 'hastings_fabric_search'
module 'hastings_format_legacy'
module 'hastings_sup'
module 'hastings_handle_info_tests'
  hastings handle info test
    hastings_handle_info_tests:52: handle_info_test...[1.137 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 1.326 s]
  [done in 1.495 s]
module 'hastings_ken_tests'
  Ken Tests
    hastings_ken_tests:55: ken...[0.130 s] ok
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
    [done in 0.451 s]
  [done in 0.574 s]
=======================================================
  All 12 tests passed.
==> rel (eunit)
==> db (eunit)
```

## JIRA issue number
https://issues.apache.org/jira/browse/COUCHDB-3326

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

https://github.com/apache/couchdb/pull/1370

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;

