### PR TITLE
Avoid setting purge_seq in local doc with false

### DIFF
--- a/src/hastings_util.erl
+++ b/src/hastings_util.erl
@@ -147,6 +147,7 @@ maybe_create_local_purge_doc(Db, Index) ->
         {not_found, _Reason} ->
             DefaultPurgeSeq = couch_db:get_purge_seq(Db),
             PurgeSeq = try easton_index:get(Index#h_idx.pid, purge_seq) of
+                false -> DefaultPurgeSeq;
                 IdxPurgeSeq -> IdxPurgeSeq
             catch _:_ ->
                 DefaultPurgeSeq


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

During initial phase, the default value for purge_seq of local purge document for geo spatial index should be purge sequence of database if it doesn't exist before, and should not be false. This PR is aimed to avoid such setting to false.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provides any behaviour that the end users
     could notice? -->
make check skip_deps+=couch_epi apps=hastings tests=hastings_purge_test_

```
======================== EUnit ========================
Hastings Purge Tests
Application crypto was left running!
  hastings_purge_docs_test:69: test_purge_single...[0.260 s] ok
  hastings_purge_docs_test:84: test_purge_multiple...[0.197 s] ok
  hastings_purge_docs_test:103: test_purge_multiple2...[0.234 s] ok
  hastings_purge_docs_test:129: test_purge_local_purge_doc...[0.276 s] ok
  hastings_purge_docs_test:210: test_purge_verify_index...[0.160 s] ok
  hastings_purge_docs_test:240: test_purge_remove_local_purge_doc...[0.189 s] ok
  hastings_purge_docs_test:280: test_purge_hook_before_compaction...[0.832 s] ok
erl_child_setup: failed with error 32 on line 240
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
  [done in 3.604 s]
=======================================================
  All 7 tests passed.
```

## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

COUCHDB-3326

## Checklist

- [X] Code is written and works correctly;
- [X] Changes are covered by tests;
- [X] Documentation reflects the changes;
 


