### PR TITLE
function clause in hastings_index:handle_info/2

### DIFF
--- a/src/hastings_index.erl
+++ b/src/hastings_index.erl
@@ -339,6 +339,10 @@ handle_info({'EXIT', Pid, Reason}, #st{index=#h_idx{pid={_, Pid}}} = St) ->
     couch_log:info(Fmt, [index_name(St#st.index), Reason]),
     [gen_server:reply(P, {error, Reason}) || {P, _} <- St#st.waiting_list],
     {stop, normal, St};
+handle_info({'EXIT', Pid, Reason}, St) ->
+    % probably hastings_index_manager.
+    couch_log:notice("Unknown pid ~p closed with reason ~p", [Pid, Reason]),
+    {stop, normal, St};
 handle_info({'DOWN', _, _, DbPid, Reason}, #st{dbpid=DbPid} = St) ->
     Fmt = "~s ~s closing: Db pid ~p closing w/ reason ~w",
     couch_log:debug(Fmt, [?MODULE, index_name(St#st.index), DbPid, Reason]),


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->

Add new clause to catch the shutdown of hastings_index_manager

```
2018-12-18T00:01:35.819657Z db10.ibm004 <0.18787.5253> - gen_server <0.18787.5253> terminated with reason: no function clause matching hastings_index:handle_info({'EXIT',<0.13377.0>,shutdown}, {st,<0.13377.0>,{h_idx,{rtree,<0.13343.5358>},<<"shards/a0000000-bfffffff/paulccastro/weatherpolyg...">>,...},...})(line:296) at gen_server:try_dispatch/4(line:616) <= gen_server:handle_msg/6(line:686) <= proc_lib:init_p_do_apply/3(line:247)#012 last msg: {'EXIT',<0.13377.0>,shutdown}#012 state: {st,<0.13377.0>,{h_idx,{rtree,<0.13343.5358>},<<"shards/a0000000-bfffffff/paulccastro/weatherpolygons.1457733603">>,<<"_design/geodd">>,<<"geoidx">>,<<"function(doc) {if (doc.geometry && doc.geometry.coordinates) {st_index(doc.geometry);}}">>,<<"javascript">>,<<"rtree">>,2,4326,0,<<"e66df316792ab411705e2741bba44371">>},<0.6709.6434>,undefined,[],0}#012 
```
## Related Issues or Pull Requests

<!-- If your changes affects multiple components in different
     repositories please put links to those issues or pull requests here.  -->

https://cloudant.fogbugz.com/f/cases/114352
